### PR TITLE
Add NeedReload annotation to AssertOnNumberOfRows_IsEmpty_Test to ens…

### DIFF
--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfRows_IsEmpty_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfRows_IsEmpty_Test.java
@@ -16,6 +16,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableAssert;
 import org.assertj.db.api.TableColumnAssert;
 import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
 import org.assertj.db.type.Request;
 import org.assertj.db.type.Table;
 import org.junit.Test;
@@ -27,6 +28,7 @@ import static org.junit.Assert.fail;
  * Tests on {@link org.assertj.db.api.assertions.AssertOnNumberOfRows} class :
  * {@link AssertOnNumberOfRows#isEmpty()} method.
  */
+@NeedReload
 public class AssertOnNumberOfRows_IsEmpty_Test extends AbstractTest {
 
   /**


### PR DESCRIPTION
…ure that the test-data for subsequent tests is present.

Without this `AssertOnColumnEquality_HasValues_UUID_Test` always fails because of missing data when I run the tests in Eclipse.