### PR TITLE
Fix and improve datetime assertions

### DIFF
--- a/src/main/java/org/assertj/db/api/AbstractAssertWithValues.java
+++ b/src/main/java/org/assertj/db/api/AbstractAssertWithValues.java
@@ -19,6 +19,9 @@ import org.assertj.db.navigation.element.ValueElement;
 import org.assertj.db.navigation.origin.OriginWithColumnsAndRowsFromChange;
 import org.assertj.db.type.*;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.UUID;
 
 /**
@@ -210,6 +213,24 @@ public abstract class AbstractAssertWithValues<E extends AbstractAssertWithValue
   @Override
   public E isEqualTo(DateTimeValue expected) {
     return AssertionsOnValueEquality.isEqualTo(myself, info, value, expected);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public E isEqualTo(LocalDate expected) {
+    return isEqualTo(DateValue.from(expected));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public E isEqualTo(LocalTime expected) {
+    return isEqualTo(TimeValue.from(expected));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public E isEqualTo(LocalDateTime expected) {
+    return isEqualTo(DateTimeValue.from(expected));
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/org/assertj/db/api/AbstractAssertWithValues.java
+++ b/src/main/java/org/assertj/db/api/AbstractAssertWithValues.java
@@ -331,6 +331,24 @@ public abstract class AbstractAssertWithValues<E extends AbstractAssertWithValue
 
   /** {@inheritDoc} */
   @Override
+  public E isBefore(LocalDate date) {
+    return isBefore(DateValue.from(date));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public E isBefore(LocalTime time) {
+    return isBefore(TimeValue.from(time));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public E isBefore(LocalDateTime dateTime) {
+    return isBefore(DateTimeValue.from(dateTime));
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public E isBefore(String expected) {
     return AssertionsOnValueChronology.isBefore(myself, info, value, expected);
   }
@@ -351,6 +369,24 @@ public abstract class AbstractAssertWithValues<E extends AbstractAssertWithValue
   @Override
   public E isBeforeOrEqualTo(DateTimeValue dateTime) {
     return AssertionsOnValueChronology.isBeforeOrEqualTo(myself, info, value, dateTime);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public E isBeforeOrEqualTo(LocalDate date) {
+    return isBeforeOrEqualTo(DateValue.from(date));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public E isBeforeOrEqualTo(LocalTime time) {
+    return isBeforeOrEqualTo(TimeValue.from(time));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public E isBeforeOrEqualTo(LocalDateTime dateTime) {
+    return isBeforeOrEqualTo(DateTimeValue.from(dateTime));
   }
 
   /** {@inheritDoc} */
@@ -379,6 +415,24 @@ public abstract class AbstractAssertWithValues<E extends AbstractAssertWithValue
 
   /** {@inheritDoc} */
   @Override
+  public E isAfter(LocalDate date) {
+    return isAfter(DateValue.from(date));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public E isAfter(LocalTime time) {
+    return isAfter(TimeValue.from(time));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public E isAfter(LocalDateTime dateTime) {
+    return isAfter(DateTimeValue.from(dateTime));
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public E isAfter(String expected) {
     return AssertionsOnValueChronology.isAfter(myself, info, value, expected);
   }
@@ -399,6 +453,24 @@ public abstract class AbstractAssertWithValues<E extends AbstractAssertWithValue
   @Override
   public E isAfterOrEqualTo(DateTimeValue dateTime) {
     return AssertionsOnValueChronology.isAfterOrEqualTo(myself, info, value, dateTime);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public E isAfterOrEqualTo(LocalDate date) {
+    return isAfterOrEqualTo(DateValue.from(date));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public E isAfterOrEqualTo(LocalTime time) {
+    return isAfterOrEqualTo(TimeValue.from(time));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public E isAfterOrEqualTo(LocalDateTime dateTime) {
+    return isAfterOrEqualTo(DateTimeValue.from(dateTime));
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/org/assertj/db/api/AbstractAssertWithValues.java
+++ b/src/main/java/org/assertj/db/api/AbstractAssertWithValues.java
@@ -295,6 +295,24 @@ public abstract class AbstractAssertWithValues<E extends AbstractAssertWithValue
 
   /** {@inheritDoc} */
   @Override
+  public E isNotEqualTo(LocalDate expected) {
+    return isNotEqualTo(DateValue.from(expected));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public E isNotEqualTo(LocalTime expected) {
+    return isNotEqualTo(TimeValue.from(expected));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public E isNotEqualTo(LocalDateTime expected) {
+    return isNotEqualTo(DateTimeValue.from(expected));
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public E isBefore(DateValue date) {
     return AssertionsOnValueChronology.isBefore(myself, info, value, date);
   }

--- a/src/main/java/org/assertj/db/api/AbstractValueAssert.java
+++ b/src/main/java/org/assertj/db/api/AbstractValueAssert.java
@@ -19,6 +19,9 @@ import org.assertj.db.navigation.ToValue;
 import org.assertj.db.navigation.element.ValueElement;
 import org.assertj.db.type.*;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.UUID;
 
 /**
@@ -228,6 +231,24 @@ public abstract class AbstractValueAssert<D extends AbstractDbData<D>, A extends
   @Override
   public V isEqualTo(DateTimeValue expected) {
     return AssertionsOnValueEquality.isEqualTo(myself, info, value, expected);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public V isEqualTo(LocalDate expected) {
+    return isEqualTo(DateValue.from(expected));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public V isEqualTo(LocalTime expected) {
+    return isEqualTo(TimeValue.from(expected));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public V isEqualTo(LocalDateTime expected) {
+    return isEqualTo(DateTimeValue.from(expected));
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/org/assertj/db/api/AbstractValueAssert.java
+++ b/src/main/java/org/assertj/db/api/AbstractValueAssert.java
@@ -313,6 +313,24 @@ public abstract class AbstractValueAssert<D extends AbstractDbData<D>, A extends
 
   /** {@inheritDoc} */
   @Override
+  public V isNotEqualTo(LocalDate expected) {
+    return isNotEqualTo(DateValue.from(expected));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public V isNotEqualTo(LocalTime expected) {
+    return isNotEqualTo(TimeValue.from(expected));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public V isNotEqualTo(LocalDateTime expected) {
+    return isNotEqualTo(DateTimeValue.from(expected));
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public V isBefore(DateValue date) {
     return AssertionsOnValueChronology.isBefore(myself, info, value, date);
   }

--- a/src/main/java/org/assertj/db/api/AbstractValueAssert.java
+++ b/src/main/java/org/assertj/db/api/AbstractValueAssert.java
@@ -349,6 +349,24 @@ public abstract class AbstractValueAssert<D extends AbstractDbData<D>, A extends
 
   /** {@inheritDoc} */
   @Override
+  public V isBefore(LocalDate date) {
+    return isBefore(DateValue.from(date));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public V isBefore(LocalTime time) {
+    return isBefore(TimeValue.from(time));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public V isBefore(LocalDateTime dateTime) {
+    return isBefore(DateTimeValue.from(dateTime));
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public V isBefore(String expected) {
     return AssertionsOnValueChronology.isBefore(myself, info, value, expected);
   }
@@ -369,6 +387,24 @@ public abstract class AbstractValueAssert<D extends AbstractDbData<D>, A extends
   @Override
   public V isBeforeOrEqualTo(DateTimeValue dateTime) {
     return AssertionsOnValueChronology.isBeforeOrEqualTo(myself, info, value, dateTime);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public V isBeforeOrEqualTo(LocalDate date) {
+    return isBeforeOrEqualTo(DateValue.from(date));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public V isBeforeOrEqualTo(LocalTime time) {
+    return isBeforeOrEqualTo(TimeValue.from(time));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public V isBeforeOrEqualTo(LocalDateTime dateTime) {
+    return isBeforeOrEqualTo(DateTimeValue.from(dateTime));
   }
 
   /** {@inheritDoc} */
@@ -397,6 +433,24 @@ public abstract class AbstractValueAssert<D extends AbstractDbData<D>, A extends
 
   /** {@inheritDoc} */
   @Override
+  public V isAfter(LocalDate date) {
+    return isAfter(DateValue.from(date));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public V isAfter(LocalTime time) {
+    return isAfter(TimeValue.from(time));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public V isAfter(LocalDateTime dateTime) {
+    return isAfter(DateTimeValue.from(dateTime));
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public V isAfter(String expected) {
     return AssertionsOnValueChronology.isAfter(myself, info, value, expected);
   }
@@ -417,6 +471,24 @@ public abstract class AbstractValueAssert<D extends AbstractDbData<D>, A extends
   @Override
   public V isAfterOrEqualTo(DateTimeValue dateTime) {
     return AssertionsOnValueChronology.isAfterOrEqualTo(myself, info, value, dateTime);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public V isAfterOrEqualTo(LocalDate date) {
+    return isAfterOrEqualTo(DateValue.from(date));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public V isAfterOrEqualTo(LocalTime time) {
+    return isAfterOrEqualTo(TimeValue.from(time));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public V isAfterOrEqualTo(LocalDateTime dateTime) {
+    return isAfterOrEqualTo(DateTimeValue.from(dateTime));
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnValueChronology.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnValueChronology.java
@@ -16,6 +16,10 @@ import org.assertj.db.type.DateTimeValue;
 import org.assertj.db.type.DateValue;
 import org.assertj.db.type.TimeValue;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
 /**
  * Defines the assertion methods on the chronology of a value.
  *
@@ -66,7 +70,7 @@ public interface AssertOnValueChronology<T extends AssertOnValueChronology<T>> {
    *
    * <pre>
    * <code class='java'>
-   * assertThat(table).row().value().isBefore(TimeValue.of(2007, 12, 23));
+   * assertThat(table).row().value().isBefore(TimeValue.of(21, 29, 30));
    * </code>
    * </pre>
    * <p>
@@ -76,7 +80,7 @@ public interface AssertOnValueChronology<T extends AssertOnValueChronology<T>> {
    *
    * <pre>
    * <code class='java'>
-   * assertThat(changes).change().rowAtEndPoint().value().isBefore(TimeValue.of(2007, 12, 23));
+   * assertThat(changes).change().rowAtEndPoint().value().isBefore(TimeValue.of(21, 29, 30));
    * </code>
    * </pre>
    *
@@ -118,6 +122,99 @@ public interface AssertOnValueChronology<T extends AssertOnValueChronology<T>> {
    * @see org.assertj.db.api.AbstractAssertWithValues#isBefore(org.assertj.db.type.DateTimeValue)
    */
   T isBefore(DateTimeValue dateTime);
+
+  /**
+   * Verifies that the value is before a date value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is before a date value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isBefore(LocalDate.of(2007, 12, 23));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is before a date value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isBefore(LocalDate.of(2007, 12, 23));
+   * </code>
+   * </pre>
+   *
+   * @param date The date value to compare to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is not before to the date value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isBefore(LocalDate)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isBefore(LocalDate)
+   */
+  T isBefore(LocalDate date);
+
+  /**
+   * Verifies that the value is before a time value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is before a time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isBefore(LocalTime.of(21, 29, 30));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is before a time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isBefore(LocalTime.of(21, 29, 30));
+   * </code>
+   * </pre>
+   *
+   * @param time The time value to compare to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is not before to the time value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isBefore(LocalTime)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isBefore(LocalTime)
+   */
+  T isBefore(LocalTime time);
+
+  /**
+   * Verifies that the value is before a date/time value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is before a date/time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isBefore(LocalDateTime.of(2007, 12, 23, 21, 29));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is before a date/time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isBefore(LocalDateTime.of(2007, 12, 23, 21, 29));
+   * </code>
+   * </pre>
+   *
+   * @param dateTime The date/time value to compare to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is not before to the date/time value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isBefore(LocalDateTime)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isBefore(LocalDateTime)
+   */
+  T isBefore(LocalDateTime dateTime);
 
   /**
    * Verifies that the value is before a date, time or date/time represented by a {@code String}.
@@ -190,7 +287,7 @@ public interface AssertOnValueChronology<T extends AssertOnValueChronology<T>> {
    *
    * <pre>
    * <code class='java'>
-   * assertThat(table).row().value().isBeforeOrEqualTo(TimeValue.of(2007, 12, 23));
+   * assertThat(table).row().value().isBeforeOrEqualTo(TimeValue.of(21, 29, 30));
    * </code>
    * </pre>
    * <p>
@@ -200,7 +297,7 @@ public interface AssertOnValueChronology<T extends AssertOnValueChronology<T>> {
    *
    * <pre>
    * <code class='java'>
-   * assertThat(changes).change().rowAtEndPoint().value().isBeforeOrEqualTo(TimeValue.of(2007, 12, 23));
+   * assertThat(changes).change().rowAtEndPoint().value().isBeforeOrEqualTo(TimeValue.of(21, 29, 30));
    * </code>
    * </pre>
    *
@@ -242,6 +339,99 @@ public interface AssertOnValueChronology<T extends AssertOnValueChronology<T>> {
    * @see org.assertj.db.api.AbstractAssertWithValues#isBeforeOrEqualTo(org.assertj.db.type.DateTimeValue)
    */
   T isBeforeOrEqualTo(DateTimeValue dateTime);
+
+  /**
+   * Verifies that the value is before or equal to a date value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is before or equal to a date value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isBeforeOrEqualTo(LocalDate.of(2007, 12, 23));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is before or equal to a date value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isBeforeOrEqualTo(LocalDate.of(2007, 12, 23));
+   * </code>
+   * </pre>
+   *
+   * @param date The date value to compare to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is not before or equal to the date value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isBeforeOrEqualTo(LocalDate)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isBeforeOrEqualTo(LocalDate)
+   */
+  T isBeforeOrEqualTo(LocalDate date);
+
+  /**
+   * Verifies that the value is before or equal to a time value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is before or equal to a time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isBeforeOrEqualTo(LocalTime.of(21, 29, 30));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is before or equal to a time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isBeforeOrEqualTo(LocalTime.of(21, 29, 30));
+   * </code>
+   * </pre>
+   *
+   * @param time The time value to compare to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is not before or equal to the time value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isBeforeOrEqualTo(LocalTime)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isBeforeOrEqualTo(LocalTime)
+   */
+  T isBeforeOrEqualTo(LocalTime time);
+
+  /**
+   * Verifies that the value is before or equal to a date/time value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is before or equal to a date/time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isBeforeOrEqualTo(LocalDateTime.of(2007, 12, 23, 21, 29));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is before or equal to a date/time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isBeforeOrEqualTo(LocalDateTime.of(2007, 12, 23, 21, 29));
+   * </code>
+   * </pre>
+   *
+   * @param dateTime The date/time value to compare to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is not before or equal to the date/time value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isBeforeOrEqualTo(LocalDateTime)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isBeforeOrEqualTo(LocalDateTime)
+   */
+  T isBeforeOrEqualTo(LocalDateTime dateTime);
 
   /**
    * Verifies that the value is before or equal to a date, time or date/time represented by a {@code String}.
@@ -314,7 +504,7 @@ public interface AssertOnValueChronology<T extends AssertOnValueChronology<T>> {
    *
    * <pre>
    * <code class='java'>
-   * assertThat(table).row().value().isAfter(TimeValue.of(2007, 12, 23));
+   * assertThat(table).row().value().isAfter(TimeValue.of(21, 29, 30));
    * </code>
    * </pre>
    * <p>
@@ -324,7 +514,7 @@ public interface AssertOnValueChronology<T extends AssertOnValueChronology<T>> {
    *
    * <pre>
    * <code class='java'>
-   * assertThat(changes).change().rowAtEndPoint().value().isAfter(TimeValue.of(2007, 12, 23));
+   * assertThat(changes).change().rowAtEndPoint().value().isAfter(TimeValue.of(21, 29, 30));
    * </code>
    * </pre>
    *
@@ -366,6 +556,99 @@ public interface AssertOnValueChronology<T extends AssertOnValueChronology<T>> {
    * @see org.assertj.db.api.AbstractAssertWithValues#isAfter(org.assertj.db.type.DateTimeValue)
    */
   T isAfter(DateTimeValue dateTime);
+
+  /**
+   * Verifies that the value is after a date value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is after a date value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isAfter(LocalDate.of(2007, 12, 23));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is after a date value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isAfter(LocalDate.of(2007, 12, 23));
+   * </code>
+   * </pre>
+   *
+   * @param date The date value to compare to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is not after to the date value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isAfter(LocalDate)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isAfter(LocalDate)
+   */
+  T isAfter(LocalDate date);
+
+  /**
+   * Verifies that the value is after a time value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is after a time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isAfter(LocalTime.of(21, 29, 30));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is after a time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isAfter(LocalTime.of(21, 29, 30));
+   * </code>
+   * </pre>
+   *
+   * @param time The time value to compare to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is not after to the time value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isAfter(LocalTime)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isAfter(LocalTime)
+   */
+  T isAfter(LocalTime time);
+
+  /**
+   * Verifies that the value is after a date/time value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is after a date/time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isAfter(LocalDateTime.of(2007, 12, 23, 21, 29));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is after a date/time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isAfter(LocalDateTime.of(2007, 12, 23, 21, 29));
+   * </code>
+   * </pre>
+   *
+   * @param dateTime The date/time value to compare to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is not after to the date/time value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isAfter(LocalDateTime)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isAfter(LocalDateTime)
+   */
+  T isAfter(LocalDateTime dateTime);
 
   /**
    * Verifies that the value is after a date, time or date/time represented by a {@code String}.
@@ -438,7 +721,7 @@ public interface AssertOnValueChronology<T extends AssertOnValueChronology<T>> {
    *
    * <pre>
    * <code class='java'>
-   * assertThat(table).row().value().isAfterOrEqualTo(TimeValue.of(2007, 12, 23));
+   * assertThat(table).row().value().isAfterOrEqualTo(TimeValue.of(21, 29, 30));
    * </code>
    * </pre>
    * <p>
@@ -448,7 +731,7 @@ public interface AssertOnValueChronology<T extends AssertOnValueChronology<T>> {
    *
    * <pre>
    * <code class='java'>
-   * assertThat(changes).change().rowAtEndPoint().value().isAfterOrEqualTo(TimeValue.of(2007, 12, 23));
+   * assertThat(changes).change().rowAtEndPoint().value().isAfterOrEqualTo(TimeValue.of(21, 29, 30));
    * </code>
    * </pre>
    *
@@ -490,6 +773,99 @@ public interface AssertOnValueChronology<T extends AssertOnValueChronology<T>> {
    * @see org.assertj.db.api.AbstractAssertWithValues#isAfterOrEqualTo(org.assertj.db.type.DateTimeValue)
    */
   T isAfterOrEqualTo(DateTimeValue dateTime);
+
+  /**
+   * Verifies that the value is after or equal to a date value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is after or equal to a date value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isAfterOrEqualTo(LocalDate.of(2007, 12, 23));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is after or equal to a date value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isAfterOrEqualTo(LocalDate.of(2007, 12, 23));
+   * </code>
+   * </pre>
+   *
+   * @param date The date value to compare to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is not after or equal to the time value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isAfterOrEqualTo(LocalDate)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isAfterOrEqualTo(LocalDate)
+   */
+  T isAfterOrEqualTo(LocalDate date);
+
+  /**
+   * Verifies that the value is after or equal to a time value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is after or equal to a time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isAfterOrEqualTo(LocalTime.of(21, 29, 30));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is after or equal to a time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isAfterOrEqualTo(LocalTime.of(21, 29, 30));
+   * </code>
+   * </pre>
+   *
+   * @param time The time value to compare to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is not after or equal to the time value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isAfterOrEqualTo(LocalTime)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isAfterOrEqualTo(LocalTime)
+   */
+  T isAfterOrEqualTo(LocalTime time);
+
+  /**
+   * Verifies that the value is after or equal to a date/time value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is after or equal to a date/time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isAfterOrEqualTo(LocalDateTime.of(2007, 12, 23, 21, 29));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is after or equal to a date/time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isAfterOrEqualTo(LocalDateTime.of(2007, 12, 23, 21, 29));
+   * </code>
+   * </pre>
+   *
+   * @param dateTime The date/time value to compare to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is not after or equal to the date/time value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isAfterOrEqualTo(LocalDateTime)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isAfterOrEqualTo(LocalDateTime)
+   */
+  T isAfterOrEqualTo(LocalDateTime dateTime);
 
   /**
    * Verifies that the value is after or equal to a date, time or date/time represented by a {@code String}.

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnValueEquality.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnValueEquality.java
@@ -16,6 +16,9 @@ import org.assertj.db.type.DateTimeValue;
 import org.assertj.db.type.DateValue;
 import org.assertj.db.type.TimeValue;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.UUID;
 
 /**
@@ -400,6 +403,99 @@ public interface AssertOnValueEquality<T extends AssertOnValueEquality<T>> {
    * @see org.assertj.db.api.AbstractAssertWithValues#isEqualTo(DateTimeValue)
    */
   T isEqualTo(DateTimeValue expected);
+
+  /**
+   * Verifies that the value is equal to a date value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is equal to a date value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isEqualTo(LocalDate.of(2014, 7, 7));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is equal to a date value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isEqualTo(LocalDate.of(2014, 7, 7));
+   * </code>
+   * </pre>
+   *
+   * @param expected The expected date value.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is not equal to the date value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isEqualTo(LocalDate)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isEqualTo(LocalDate)
+   */
+  T isEqualTo(LocalDate expected);
+
+  /**
+   * Verifies that the value is equal to a time value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is equal to a time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isEqualTo(LocalTime.of(21, 29, 30));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is equal to a time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isEqualTo(LocalTime.of(21, 29, 30));
+   * </code>
+   * </pre>
+   *
+   * @param expected The expected time value.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is not equal to the time value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isEqualTo(LocalTime)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isEqualTo(LocalTime)
+   */
+  T isEqualTo(LocalTime expected);
+
+  /**
+   * Verifies that the value is equal to a date/time value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is equal to a date/time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isEqualTo(LocalDateTime.of(2014, 7, 7, 21, 29));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is equal to a date/time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isEqualTo(LocalDateTime.of(2014, 7, 7, 21, 29));
+   * </code>
+   * </pre>
+   *
+   * @param expected The expected date/time value.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is not equal to the date/time value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isEqualTo(LocalDateTime)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isEqualTo(LocalDateTime)
+   */
+  T isEqualTo(LocalDateTime expected);
 
   /**
    * Verifies that the value is equal to zero.

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnValueInequality.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnValueInequality.java
@@ -16,6 +16,9 @@ import org.assertj.db.type.DateTimeValue;
 import org.assertj.db.type.DateValue;
 import org.assertj.db.type.TimeValue;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.UUID;
 
 /**
@@ -342,6 +345,99 @@ public interface AssertOnValueInequality<T extends AssertOnValueInequality<T>> {
    * @see org.assertj.db.api.AbstractAssertWithValues#isNotEqualTo(TimeValue)
    */
   T isNotEqualTo(TimeValue expected);
+
+  /**
+   * Verifies that the value is not equal to a date value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is not equal to a date value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isNotEqualTo(LocalDate.of(2014, 7, 7));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is not equal to a date value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isNotEqualTo(LocalDate.of(2014, 7, 7));
+   * </code>
+   * </pre>
+   *
+   * @param expected The expected date value.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is equal to the date value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isNotEqualTo(LocalDate)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isNotEqualTo(LocalDate)
+   */
+  T isNotEqualTo(LocalDate expected);
+
+  /**
+   * Verifies that the value is not equal to a time value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is not equal to a time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isNotEqualTo(LocalTime.of(21, 29, 30));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is not equal to a time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isNotEqualTo(LocalTime.of(21, 29, 30));
+   * </code>
+   * </pre>
+   *
+   * @param expected The expected time value.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is equal to the time value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isNotEqualTo(LocalTime)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isNotEqualTo(LocalTime)
+   */
+  T isNotEqualTo(LocalTime expected);
+
+  /**
+   * Verifies that the value is not equal to a date/time value.
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the first {@code Row} of the
+   * {@code Table} is not equal to a date/time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(table).row().value().isNotEqualTo(LocalDateTime.of(2014, 7, 7, 21, 29));
+   * </code>
+   * </pre>
+   * <p>
+   * Example where the assertion verifies that the value in the first {@code Column} of the {@code Row} at end point
+   * of the first {@code Change} is not equal to a date/time value :
+   * </p>
+   *
+   * <pre>
+   * <code class='java'>
+   * assertThat(changes).change().rowAtEndPoint().value().isNotEqualTo(LocalDateTime.of(2014, 7, 7, 21, 29));
+   * </code>
+   * </pre>
+   *
+   * @param expected The expected date/time value.
+   * @return {@code this} assertion object.
+   * @throws AssertionError If the value is equal to the date/time value in parameter.
+   * @see org.assertj.db.api.AbstractValueAssert#isNotEqualTo(LocalDateTime)
+   * @see org.assertj.db.api.AbstractAssertWithValues#isNotEqualTo(LocalDateTime)
+   */
+  T isNotEqualTo(LocalDateTime expected);
 
   /**
    * Verifies that the value is not equal to zero.

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_LocalDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_LocalDateTime_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueChronology} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueChronology#isAfterOrEqualTo(java.time.LocalDateTime)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueChronology_IsAfterOrEqualTo_LocalDateTime_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isAfterOrEqualTo} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_after_or_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var10").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isAfterOrEqualTo(LocalDateTime.of(2014, 5, 24, 9, 46, 30));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var10").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isAfterOrEqualTo(LocalDateTime.of(2014, 5, 24, 9, 46, 30));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is before.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_before() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var10").valueAtEndPoint().isAfterOrEqualTo(LocalDateTime.of(2014, 5, 24, 9, 46, 31));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 9 (column name : VAR10) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be after or equal to %n"
+                                                      + "  <2014-05-24T09:46:31.000000000>"));
+    }
+    try {
+      assertThat(table).column("var10").value().isAfterOrEqualTo(LocalDateTime.of(2014, 5, 24, 9, 46, 31));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 9 (column name : VAR10) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be after or equal to %n"
+                                                      + "  <2014-05-24T09:46:31.000000000>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_LocalDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_LocalDate_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueChronology} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueChronology#isAfterOrEqualTo(java.time.LocalDate)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueChronology_IsAfterOrEqualTo_LocalDate_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isAfterOrEqualTo} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_after_or_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var10").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isAfterOrEqualTo(LocalDate.of(2014, 5, 24));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var10").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isAfterOrEqualTo(LocalDate.of(2014, 5, 24));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is before.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_before() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var10").valueAtEndPoint().isAfterOrEqualTo(LocalDate.of(2014, 5, 25));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 9 (column name : VAR10) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be after or equal to %n"
+                                                      + "  <2014-05-25T00:00:00.000000000>"));
+    }
+    try {
+      assertThat(table).column("var10").value().isAfterOrEqualTo(LocalDate.of(2014, 5, 25));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 9 (column name : VAR10) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be after or equal to %n"
+                                                      + "  <2014-05-25T00:00:00.000000000>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_LocalTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_LocalTime_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueChronology} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueChronology#isAfterOrEqualTo(java.time.LocalTime)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueChronology_IsAfterOrEqualTo_LocalTime_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isAfterOrEqualTo} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_after_or_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var8").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isAfterOrEqualTo(LocalTime.of(9, 46, 30));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var8").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isAfterOrEqualTo(LocalTime.of(9, 46, 30));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is before.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_before() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var8").valueAtEndPoint().isAfterOrEqualTo(LocalTime.of(9, 46, 31));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 7 (column name : VAR8) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <09:46:30.000000000>%n"
+                                                      + "to be after or equal to %n"
+                                                      + "  <09:46:31.000000000>"));
+    }
+    try {
+      assertThat(table).column("var8").value().isAfterOrEqualTo(LocalTime.of(9, 46, 31));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 7 (column name : VAR8) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <09:46:30.000000000>%n"
+                                                      + "to be after or equal to %n"
+                                                      + "  <09:46:31.000000000>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_LocalDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_LocalDateTime_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueChronology} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueChronology#isAfter(java.time.LocalDateTime)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueChronology_IsAfter_LocalDateTime_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isAfter} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_after() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var10").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isAfter(LocalDateTime.of(2014, 5, 24, 9, 46, 29));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var10").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isAfter(LocalDateTime.of(2014, 5, 24, 9, 46, 29));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is before or equal to.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_before_or_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var10").valueAtEndPoint().isAfter(LocalDateTime.of(2014, 5, 24, 9, 46, 30));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 9 (column name : VAR10) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be after %n"
+                                                      + "  <2014-05-24T09:46:30.000000000>"));
+    }
+    try {
+      assertThat(table).column("var10").value().isAfter(LocalDateTime.of(2014, 5, 24, 9, 46, 30));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 9 (column name : VAR10) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be after %n"
+                                                      + "  <2014-05-24T09:46:30.000000000>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_LocalDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_LocalDate_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueChronology} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueChronology#isAfter(java.time.LocalDate)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueChronology_IsAfter_LocalDate_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isAfter} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_after() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var10").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isAfter(LocalDate.of(2014, 5, 24));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var10").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isAfter(LocalDate.of(2014, 5, 24));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is before or equal to.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_before_or_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var10").valueAtEndPoint().isAfter(LocalDate.of(2014, 5, 25));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 9 (column name : VAR10) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be after %n"
+                                                      + "  <2014-05-25T00:00:00.000000000>"));
+    }
+    try {
+      assertThat(table).column("var10").value().isAfter(LocalDate.of(2014, 5, 25));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 9 (column name : VAR10) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be after %n"
+                                                      + "  <2014-05-25T00:00:00.000000000>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_LocalTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_LocalTime_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueChronology} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueChronology#isAfter(java.time.LocalTime)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueChronology_IsAfter_LocalTime_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isAfter} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_after() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var8").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isAfter(LocalTime.of(9, 46, 29));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var8").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isAfter(LocalTime.of(9, 46, 29));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is before or equal to.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_before_or_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var8").valueAtEndPoint().isAfter(LocalTime.of(9, 46, 30));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 7 (column name : VAR8) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <09:46:30.000000000>%n"
+                                                      + "to be after %n"
+                                                      + "  <09:46:30.000000000>"));
+    }
+    try {
+      assertThat(table).column("var8").value().isAfter(LocalTime.of(9, 46, 30));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 7 (column name : VAR8) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <09:46:30.000000000>%n"
+                                                      + "to be after %n"
+                                                      + "  <09:46:30.000000000>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_LocalDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_LocalDateTime_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueChronology} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueChronology#isBeforeOrEqualTo(java.time.LocalDateTime)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueChronology_IsBeforeOrEqualTo_LocalDateTime_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isBeforeOrEqualTo} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_before_or_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var10").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isBeforeOrEqualTo(LocalDateTime.of(2014, 5, 24, 9, 46, 30));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var10").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isBeforeOrEqualTo(LocalDateTime.of(2014, 5, 24, 9, 46, 30));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is after.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_after() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var10").valueAtEndPoint().isBeforeOrEqualTo(LocalDateTime.of(2014, 5, 24, 9, 46, 29));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 9 (column name : VAR10) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be before or equal to %n"
+                                                      + "  <2014-05-24T09:46:29.000000000>"));
+    }
+    try {
+      assertThat(table).column("var10").value().isBeforeOrEqualTo(LocalDateTime.of(2014, 5, 24, 9, 46, 29));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 9 (column name : VAR10) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be before or equal to %n"
+                                                      + "  <2014-05-24T09:46:29.000000000>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_LocalDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_LocalDate_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueChronology} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueChronology#isBeforeOrEqualTo(java.time.LocalDate)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueChronology_IsBeforeOrEqualTo_LocalDate_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isBeforeOrEqualTo} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_before_or_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var10").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isBeforeOrEqualTo(LocalDate.of(2014, 5, 25));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var10").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isBeforeOrEqualTo(LocalDate.of(2014, 5, 25));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is after.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_after() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var10").valueAtEndPoint().isBeforeOrEqualTo(LocalDate.of(2014, 5, 24));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 9 (column name : VAR10) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be before or equal to %n"
+                                                      + "  <2014-05-24T00:00:00.000000000>"));
+    }
+    try {
+      assertThat(table).column("var10").value().isBeforeOrEqualTo(LocalDate.of(2014, 5, 24));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 9 (column name : VAR10) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be before or equal to %n"
+                                                      + "  <2014-05-24T00:00:00.000000000>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_LocalTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_LocalTime_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueChronology} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueChronology#isBeforeOrEqualTo(java.time.LocalTime)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueChronology_IsBeforeOrEqualTo_LocalTime_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isBeforeOrEqualTo} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_before_or_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var8").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isBeforeOrEqualTo(LocalTime.of(9, 46, 30));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var8").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isBeforeOrEqualTo(LocalTime.of(9, 46, 30));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is after.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_after() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var8").valueAtEndPoint().isBeforeOrEqualTo(LocalTime.of(9, 46, 29));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 7 (column name : VAR8) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <09:46:30.000000000>%n"
+                                                      + "to be before or equal to %n"
+                                                      + "  <09:46:29.000000000>"));
+    }
+    try {
+      assertThat(table).column("var8").value().isBeforeOrEqualTo(LocalTime.of(9, 46, 29));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 7 (column name : VAR8) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <09:46:30.000000000>%n"
+                                                      + "to be before or equal to %n"
+                                                      + "  <09:46:29.000000000>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_LocalDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_LocalDateTime_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueChronology} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueChronology#isBefore(java.time.LocalDateTime)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueChronology_IsBefore_LocalDateTime_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isBefore} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_before() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var10").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isBefore(LocalDateTime.of(2014, 5, 24, 9, 46, 31));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var10").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isBefore(LocalDateTime.of(2014, 5, 24, 9, 46, 31));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is after or equal to.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_after_or_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var10").valueAtEndPoint().isBefore(LocalDateTime.of(2014, 5, 24, 9, 46, 30));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 9 (column name : VAR10) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be before %n"
+                                                      + "  <2014-05-24T09:46:30.000000000>"));
+    }
+    try {
+      assertThat(table).column("var10").value().isBefore(LocalDateTime.of(2014, 5, 24, 9, 46, 30));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 9 (column name : VAR10) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be before %n"
+                                                      + "  <2014-05-24T09:46:30.000000000>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_LocalDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_LocalDate_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueChronology} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueChronology#isBefore(java.time.LocalDate)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueChronology_IsBefore_LocalDate_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isBefore} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_before() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var10").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isBefore(LocalDate.of(2014, 5, 25));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var10").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isBefore(LocalDate.of(2014, 5, 25));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is after or equal to.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_after_or_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var10").valueAtEndPoint().isBefore(LocalDate.of(2014, 5, 24));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 9 (column name : VAR10) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be before %n"
+                                                      + "  <2014-05-24T00:00:00.000000000>"));
+    }
+    try {
+      assertThat(table).column("var10").value().isBefore(LocalDate.of(2014, 5, 24));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 9 (column name : VAR10) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be before %n"
+                                                      + "  <2014-05-24T00:00:00.000000000>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_LocalTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_LocalTime_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueChronology} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueChronology#isBefore(java.time.LocalTime)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueChronology_IsBefore_LocalTime_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isBefore} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_before() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var8").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isBefore(LocalTime.of(9, 46, 31));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var8").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isBefore(LocalTime.of(9, 46, 31));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is after or equal to.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_after_or_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var8").valueAtEndPoint().isBefore(LocalTime.of(9, 46, 30));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 7 (column name : VAR8) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <09:46:30.000000000>%n"
+                                                      + "to be before %n"
+                                                      + "  <09:46:30.000000000>"));
+    }
+    try {
+      assertThat(table).column("var8").value().isBefore(LocalTime.of(9, 46, 30));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 7 (column name : VAR8) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <09:46:30.000000000>%n"
+                                                      + "to be before %n"
+                                                      + "  <09:46:30.000000000>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_LocalDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_LocalDateTime_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueEquality} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueEquality#isEqualTo(java.time.LocalDateTime)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueEquality_IsEqualTo_LocalDateTime_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isEqualTo} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var10").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isEqualTo(LocalDateTime.of(2014, 5, 24, 9, 46, 30));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var10").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isEqualTo(LocalDateTime.of(2014, 5, 24, 9, 46, 30));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is no equal to.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_not_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var10").valueAtEndPoint().isEqualTo(LocalDateTime.of(2014, 5, 24, 9, 46, 31));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 9 (column name : VAR10) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be equal to: %n"
+                                                      + "  <2014-05-24T09:46:31.000000000>"));
+    }
+    try {
+      assertThat(table).column("var10").value().isEqualTo(LocalDateTime.of(2014, 5, 24, 9, 46, 31));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 9 (column name : VAR10) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "to be equal to: %n"
+                                                      + "  <2014-05-24T09:46:31.000000000>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_LocalDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_LocalDate_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueEquality} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueEquality#isEqualTo(java.time.LocalDate)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueEquality_IsEqualTo_LocalDate_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isEqualTo} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var9").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isEqualTo(LocalDate.of(2014, 5, 24));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var9").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isEqualTo(LocalDate.of(2014, 5, 24));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is no equal to.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_not_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var9").valueAtEndPoint().isEqualTo(LocalDate.of(2014, 5, 23));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 8 (column name : VAR9) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24>%n"
+                                                      + "to be equal to: %n"
+                                                      + "  <2014-05-23>"));
+    }
+    try {
+      assertThat(table).column("var9").value().isEqualTo(LocalDate.of(2014, 5, 23));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 8 (column name : VAR9) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24>%n"
+                                                      + "to be equal to: %n"
+                                                      + "  <2014-05-23>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_LocalTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_LocalTime_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueEquality} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueEquality#isEqualTo(java.time.LocalTime)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueEquality_IsEqualTo_LocalTime_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isEqualTo} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var8").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isEqualTo(LocalTime.of(9, 46, 30));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var8").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isEqualTo(LocalTime.of(9, 46, 30));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is greater than or equal to.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_not_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var8").valueAtEndPoint().isEqualTo(LocalTime.of(9, 46, 31));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 7 (column name : VAR8) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <09:46:30.000000000>%n"
+                                                      + "to be equal to: %n"
+                                                      + "  <09:46:31.000000000>"));
+    }
+    try {
+      assertThat(table).column("var8").value().isEqualTo(LocalTime.of(9, 46, 31));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 7 (column name : VAR8) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <09:46:30.000000000>%n"
+                                                      + "to be equal to: %n"
+                                                      + "  <09:46:31.000000000>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_LocalDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_LocalDateTime_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueInequality} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueInequality#isNotEqualTo(java.time.LocalDateTime)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueInequality_IsNotEqualTo_LocalDateTime_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isNotEqualTo} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_not_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var10").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isNotEqualTo(LocalDateTime.of(2014, 5, 24, 9, 46, 31));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var10").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isNotEqualTo(LocalDateTime.of(2014, 5, 24, 9, 46, 31));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is equal to.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var10").valueAtEndPoint().isNotEqualTo(LocalDateTime.of(2014, 5, 24, 9, 46, 30));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 9 (column name : VAR10) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "not to be equal to: %n"
+                                                      + "  <2014-05-24T09:46:30.000000000>"));
+    }
+    try {
+      assertThat(table).column("var10").value().isNotEqualTo(LocalDateTime.of(2014, 5, 24, 9, 46, 30));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 9 (column name : VAR10) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24T09:46:30.000000000>%n"
+                                                      + "not to be equal to: %n"
+                                                      + "  <2014-05-24T09:46:30.000000000>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_LocalDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_LocalDate_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueInequality} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueInequality#isNotEqualTo(java.time.LocalDate)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueInequality_IsNotEqualTo_LocalDate_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isNotEqualTo} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_not_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var9").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isNotEqualTo(LocalDate.of(2007, 12, 23));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var9").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isNotEqualTo(LocalDate.of(2007, 12, 23));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is greater than or equal to.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var9").valueAtEndPoint().isNotEqualTo(LocalDate.of(2014, 5, 24));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 8 (column name : VAR9) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24>%n"
+                                                      + "not to be equal to: %n"
+                                                      + "  <2014-05-24>"));
+    }
+    try {
+      assertThat(table).column("var9").value().isNotEqualTo(LocalDate.of(2014, 5, 24));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 8 (column name : VAR9) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <2014-05-24>%n"
+                                                      + "not to be equal to: %n"
+                                                      + "  <2014-05-24>"));
+    }
+  }
+}

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_LocalTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_LocalTime_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2015-2020 the original author or authors.
+ */
+package org.assertj.db.api.assertions;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.db.api.ChangeColumnValueAssert;
+import org.assertj.db.api.TableColumnValueAssert;
+import org.assertj.db.common.AbstractTest;
+import org.assertj.db.common.NeedReload;
+import org.assertj.db.type.Changes;
+import org.assertj.db.type.Table;
+import org.junit.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.db.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests on {@link org.assertj.db.api.assertions.AssertOnValueInequality} class :
+ * {@link org.assertj.db.api.assertions.AssertOnValueInequality#isNotEqualTo(java.time.LocalTime)} method.
+ *
+ * @author Yosuke Nishikawa
+ */
+public class AssertOnValueInequality_IsNotEqualTo_LocalTime_Test extends AbstractTest {
+
+  /**
+   * This method tests the {@code isNotEqualTo} assertion method.
+   */
+  @Test
+  @NeedReload
+  public void test_is_not_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    ChangeColumnValueAssert changeColumnValueAssert = assertThat(changes).change().column("var8").valueAtEndPoint();
+    ChangeColumnValueAssert changeColumnValueAssert2 = changeColumnValueAssert.isNotEqualTo(LocalTime.of(9, 30, 6));
+    Assertions.assertThat(changeColumnValueAssert).isSameAs(changeColumnValueAssert2);
+
+    TableColumnValueAssert tableColumnValueAssert = assertThat(table).column("var8").value();
+    TableColumnValueAssert tableColumnValueAssert2 = tableColumnValueAssert.isNotEqualTo(LocalTime.of(9, 30, 6));
+    Assertions.assertThat(tableColumnValueAssert).isSameAs(tableColumnValueAssert2);
+  }
+
+  /**
+   * This method should fail because the value is equal to.
+   */
+  @Test
+  @NeedReload
+  public void should_fail_because_value_is_equal_to() {
+    Table table = new Table(source, "test");
+    Changes changes = new Changes(table).setStartPointNow();
+    update("update test set var14 = 1 where var1 = 1");
+    changes.setEndPointNow();
+
+    try {
+      assertThat(changes).change().column("var8").valueAtEndPoint().isNotEqualTo(LocalTime.of(9, 46, 30));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at end point of Column at index 7 (column name : VAR8) of Change at index 0 (with primary key : [1]) of Changes on TEST table of 'sa/jdbc:h2:mem:test' source] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <09:46:30.000000000>%n"
+                                                      + "not to be equal to: %n"
+                                                      + "  <09:46:30.000000000>"));
+    }
+    try {
+      assertThat(table).column("var8").value().isNotEqualTo(LocalTime.of(9, 46, 30));
+      fail("An exception must be raised");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(String.format("[Value at index 0 of Column at index 7 (column name : VAR8) of TEST table] %n"
+                                                      + "Expecting:%n"
+                                                      + "  <09:46:30.000000000>%n"
+                                                      + "not to be equal to: %n"
+                                                      + "  <09:46:30.000000000>"));
+    }
+  }
+}


### PR DESCRIPTION
Unfortunately, #86 does not work as expected when calling `assertThat(Table)` or `assertThat(Changes)`. Furthermore, assertions for inequality and order relations in JSR-310 type values were not implemented.

This PR is a fix for the 'IsEqualTo' assertion, and allows us to use below assertions in JSR-310 type values:

* `isNotEqualTo(T)`

* `isBefore(T)`

* `isBeforeOrEqualTo(T)`

* `isAfter(T)`

* `isAfterOrEqualTo(T)`

T := LocalDate, LocalTime or LocalDateTime